### PR TITLE
Dependabot config updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,3 @@ updates:
   directory: "/"
   schedule:
     interval: "monthly"
-  open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
+    interval: "monthly"
   open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: "monthly"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: "monthly"


### PR DESCRIPTION
- Switch to monthly Dependabot updates - daily is overkill
- Use default Dependabot open PR limit
- Use Dependabot for GitHub Actions
