### PR TITLE
Install Pipenv *after* setting up Python

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,14 +20,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install Pipenv
-      run: pipx install pipenv
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         cache: pipenv
+
+    - name: Install Pipenv
+      run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
 
     - name: Install dependencies
       run: pipenv install --dev


### PR DESCRIPTION
That way we get a properly-versioned Pipenv, and not one trying to use system Python